### PR TITLE
Support Proxies That Set Additional Cookies

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: cachix/install-nix-action@v6
+    - name: free disk space
+      run: |
+        sudo rm -rf /opt
     - uses: cachix/cachix-action@releases/v3
       with:
         name: validity

--- a/tickler-api/src/Tickler/API.hs
+++ b/tickler-api/src/Tickler/API.hs
@@ -19,8 +19,6 @@ import Import
 
 import Data.UUID.Typed
 
-import Web.Cookie
-
 import Servant.API
 import Servant.API.Generic
 import Servant.Auth.Docs ()
@@ -72,7 +70,7 @@ data TicklerPublicSite route =
 type PostRegister = "register" :> ReqBody '[ JSON] Registration :> Post '[ JSON] NoContent
 
 type PostLogin
-   = "login" :> ReqBody '[ JSON] LoginForm :> PostNoContent '[ JSON] (Headers '[ Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] NoContent)
+   = "login" :> ReqBody '[ JSON] LoginForm :> PostNoContent '[ JSON] (Headers '[ Header "Set-Cookie" Text] NoContent)
 
 type GetLoopersStatus = "loopers" :> Get '[ JSON] LoopersInfo
 

--- a/tickler-cli/src/Tickler/Cli/Commands/Login.hs
+++ b/tickler-cli/src/Tickler/Cli/Commands/Login.hs
@@ -10,7 +10,10 @@ module Tickler.Cli.Commands.Login
 
 import Import
 
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
 import Servant
+import Web.Cookie
 
 import Tickler.API
 
@@ -34,10 +37,15 @@ login LoginSettings {..} = do
       clientPostLogin loginForm
   case mRes of
     Nothing -> liftIO $ die "No server configured."
-    Just (Headers NoContent (HCons _ (HCons sessionHeader HNil))) ->
+    Just (Headers NoContent (HCons sessionHeader HNil)) ->
       case sessionHeader of
         MissingHeader ->
           liftIO $ die "The server responded but the response was missing the right session header."
         UndecodableHeader _ ->
           liftIO $ die "The server responded but the response had an undecodable session header."
-        Header setCookie -> saveSession setCookie
+        Header cookieText -> do
+          let cookies = parseSetCookie . encodeUtf8 <$> T.lines cookieText
+              jwtCookie = find ((== "JWT-Cookie") . setCookieName) cookies
+          case jwtCookie of
+            Nothing -> liftIO $ die "The server responded but the response contained no JWT-Cookie."
+            Just setCookie -> saveSession setCookie

--- a/tickler-client/src/Tickler/Client.hs
+++ b/tickler-client/src/Tickler/Client.hs
@@ -17,7 +17,6 @@ import qualified Data.UUID.Typed
 import Servant.API
 import Servant.API.Flatten
 import Servant.Auth.Client
-import Servant.Auth.Server hiding (BasicAuth)
 import Servant.Client
 
 import Tickler.API
@@ -48,9 +47,7 @@ clientGetAccountSettings :: Token -> ClientM AccountSettings
 clientPutAccountSettings :: Token -> AccountSettings -> ClientM NoContent
 clientDeleteAccount :: Token -> ClientM NoContent
 clientPostRegister :: Registration -> ClientM NoContent
-clientPostLogin ::
-     LoginForm
-  -> ClientM (Headers '[ Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] NoContent)
+clientPostLogin :: LoginForm -> ClientM (Headers '[ Header "Set-Cookie" Text] NoContent)
 clientGetLoopersInfo :: ClientM LoopersInfo
 clientGetDocs :: ClientM GetDocsResponse
 clientGetPricing :: ClientM (Maybe Pricing)


### PR DESCRIPTION
Ripped from https://github.com/NorfairKing/smos/pull/46 & https://github.com/NorfairKing/intray/pull/7

---

Add support for using the CLI client with proxied servers that append
their own cookies to the Set-Cookie header returned by the PostLogin API
route.

For example, servers proxied behind CloudFlare will get a __cfuid cookie
appended to the Set-Cookie header. Previously, the client would
incorrectly save the __cfuid cookie to the session.cookie file. We
prevent this by having the client's PostLogin handler parse the Cookies
itself, locate the correct JWT-Cookie cookie, and explicitly save that
cookie, instead relying on Servant's SetCookie parsing which simply
parses the first cookie it sees.

We also collapse the double "Set-Cookie" Header in the PostLogin API
route since it is no longer necessary.